### PR TITLE
[no_std] should be declared in binary crate root instead of library. .

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,6 @@
 //!
 //! [`embedded-hal`]: https://docs.rs/embedded-hal/
 
-#![deny(missing_docs)]
-#![deny(warnings)]
-#![no_std]
-
 use core::cmp;
 
 use embedded_hal::blocking::i2c::{Read, Write, WriteRead};


### PR DESCRIPTION
…Otherwise it cannot be used by std projects

When I try to use si7021 master in another project without this patch, I get following build errors:
https://gitlab.com/krystian.wojtas/weather_station/-/jobs/438899063